### PR TITLE
check for license header on each source file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,7 +83,8 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "App\\Tests\\": "tests/"
+            "App\\Tests\\": "tests/",
+            "Antilope\\": "standards/Antilope/"
         }
     },
     "replace": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -17,9 +17,17 @@
     <file>public/</file>
     <file>src/</file>
     <file>tests/</file>
+    <file>standards/</file>
 
     <!-- Include the whole PSR12 standard -->
     <rule ref="PSR12"></rule>
+
+    <!-- Include Antilope custom ruleset -->
+    <rule ref="./standards/Antilope">
+        <exclude-pattern>*/config/*</exclude-pattern>
+        <exclude-pattern>*/public/*</exclude-pattern>
+        <exclude-pattern>*/tests/*</exclude-pattern>
+    </rule>
 
     <!-- Add some rules -->
     <rule ref="Generic.Metrics.NestingLevel"></rule>

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,6 +13,7 @@ parameters:
         - tests
     excludes_analyse:
         - vendor/*
+        - standards/*
     symfony:
         container_xml_path: var/cache/dev/App_KernelDevDebugContainer.xml
         console_application_loader: build/console-loader.php

--- a/src/Service/SchemeProcessor.php
+++ b/src/Service/SchemeProcessor.php
@@ -1,9 +1,39 @@
 <?php
 
+/**
+ * This file is part of Antilope
+ *
+ * Antilope is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * PHP version 7.2
+ *
+ * @package Antilope
+ * @author Nicolas Peugnet <n.peugnet@free.fr>
+ * @copyright 2020-2021 Nicolas Peugnet
+ * @license https://www.gnu.org/licenses/agpl-3.0.txt AGPL-3.0-or-later
+ */
+
 namespace App\Service;
 
 use Symfony\Component\DependencyInjection\EnvVarProcessorInterface;
 
+/**
+ * Environment variable processor to extract the scheme part of an url.
+ *
+ * This class is used in config files as an env var processor.
+ * Primarily to get the driver part of a db url in doctrine_migrations.yaml.
+ */
 class SchemeProcessor implements EnvVarProcessorInterface
 {
     public function getEnv(string $prefix, string $name, \Closure $getEnv)

--- a/standards/Antilope/Sniffs/Commenting/FileCommentSniff.php
+++ b/standards/Antilope/Sniffs/Commenting/FileCommentSniff.php
@@ -1,0 +1,92 @@
+<?php
+
+/**
+ * This file is part of Antilope
+ *
+ * Antilope is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ *
+ * PHP version 7.2
+ *
+ * @package Antilope
+ * @author Nicolas Peugnet <n.peugnet@free.fr>
+ * @copyright 2020-2021 Nicolas Peugnet
+ * @license https://www.gnu.org/licenses/agpl-3.0.txt AGPL-3.0-or-later
+ */
+
+namespace Antilope\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Standards\PEAR\Sniffs\Commenting\FileCommentSniff as PEARFileCommentSniff;
+
+/**
+ * Parses and verifies the doc comments for files.
+ *
+ * The primary goal of this sniff is to enforce the license and copyright
+ * infos to be at the top of each source file.
+ * It is an extention of PEAR's FileComment sniff with less strict rules.
+ * Only the @package, @author, @copyright and @license tags are required.
+ */
+class FileCommentSniff extends PEARFileCommentSniff
+{
+    /**
+     * Tags in correct order and related info.
+     *
+     * @var array
+     */
+    protected $tags = [
+        '@category'   => [
+            'required'       => false,
+            'allow_multiple' => false,
+        ],
+        '@package'    => [
+            'required'       => true,
+            'allow_multiple' => false,
+        ],
+        '@subpackage' => [
+            'required'       => false,
+            'allow_multiple' => false,
+        ],
+        '@author'     => [
+            'required'       => true,
+            'allow_multiple' => true,
+        ],
+        '@copyright'  => [
+            'required'       => true,
+            'allow_multiple' => true,
+        ],
+        '@license'    => [
+            'required'       => true,
+            'allow_multiple' => false,
+        ],
+        '@version'    => [
+            'required'       => false,
+            'allow_multiple' => false,
+        ],
+        '@link'       => [
+            'required'       => false,
+            'allow_multiple' => true,
+        ],
+        '@see'        => [
+            'required'       => false,
+            'allow_multiple' => true,
+        ],
+        '@since'      => [
+            'required'       => false,
+            'allow_multiple' => true,
+        ],
+        '@deprecated' => [
+            'required'       => false,
+            'allow_multiple' => false,
+        ],
+    ];
+}

--- a/standards/Antilope/ruleset.xml
+++ b/standards/Antilope/ruleset.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" ?>
+<ruleset name="Antilope"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="../../vendor/squizlabs/php_codesniffer/phpcs.xsd">
+    <description>Antilope custom coding standard.</description>
+</ruleset>


### PR DESCRIPTION
This will help remembering to add the license and copyright information to each source file. You should merge this after adding the license.
You can copy and edit the one that I wrote in this file:
https://github.com/vincent-peugnet/antilope/blob/71529f1617b5bfde7fa2ee078fb854840ce9d061/standards/Antilope/Sniffs/Commenting/FileCommentSniff.php#L3-L25

I don't really like  the `PHP version 7.2` line, but as I reused the sniff made to check the [rules of PEAR packages](https://pear.php.net/manual/en/standards.sample.php) it is for now mandatory.