### PR TITLE
Add github action to run checks on push and pr to main

### DIFF
--- a/.github/matchers/phpcs.json
+++ b/.github/matchers/phpcs.json
@@ -1,0 +1,19 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "phpcs",
+            "fileLocation": "relative",
+            "pattern": [
+                {
+                    "regexp": "^\"(.+)\",(\\d+),(\\d+),(.+),\"(.+)\",(.+),(\\d+),(\\d+)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5,
+                    "code": 6
+                }
+            ]
+        }
+    ]
+}

--- a/.github/matchers/phplint.json
+++ b/.github/matchers/phplint.json
@@ -1,0 +1,16 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "phplint",
+            "fileLocation": "relative",
+            "pattern": [
+                {
+                    "regexp": "^(.+)\\sin\\s(\\./.+\\.php)\\son\\sline\\s(\\d+)$",
+                    "message": 1,
+                    "file": 2,
+                    "line": 3
+                }
+            ]
+        }
+    ]
+}

--- a/.github/matchers/phpunit.json
+++ b/.github/matchers/phpunit.json
@@ -1,0 +1,25 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "phpunit",
+            "fileLocation": "absolute",
+            "pattern": [
+                {
+                    "regexp": "^\\d+\\)\\s.*$"
+                },
+                {
+                    "regexp": "^(.*)$",
+                    "message": 1
+                },
+                {
+                    "regexp": "^\\s*$"
+                },
+                {
+                    "regexp": "^(.*):(\\d+)$",
+                    "file": 1,
+                    "line": 2
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,44 @@
+name: build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  php-checks:
+    name: php checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        with:
+          php-version: 7.2
+          extensions: mbstring
+
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v1
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run checks
+        run: composer check

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,21 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: Install dependencies
-        run: composer install --prefer-dist --no-progress
+        run: |
+          echo "::add-matcher::.github/matchers/phplint.json"
+          composer install --prefer-dist --no-progress
 
       - name: Run checks
-        run: composer check
+        run: |
+          echo "::add-matcher::.github/matchers/phpcs.json"
+          echo "::add-matcher::.github/matchers/phpunit.json"
+
+          export PHPLINT_FLAGS="--no-progress"
+          export PHPCS_FLAGS="--report=csv -q"
+          export PHPSTAN_FLAGS="--no-progress"
+
+          composer check
+
+          echo "::remove-matcher owner=phpunit::"
+          echo "::remove-matcher owner=phpcs::"
+          echo "::remove-matcher owner=phplint::"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Antilope 
+# Antilope
+
+[![build][build-badge]][build-url] ![style][codestyle] ![phpstan][phpstan]
 
 __Antilope__ is the name of this __Sharable Network Tracker__.
 
@@ -131,3 +133,8 @@ For now, the only way to install an Antilope app is via Symfony and `composer`.
 
     bin/console doctrine:migrations:diff --db-configuration sqlite
 
+<!-- long url references -->
+[build-badge]:https://img.shields.io/github/workflow/status/vincent-peugnet/antilope/build/main
+[build-url]:https://github.com/vincent-peugnet/antilope/actions?query=branch%3Amain++workflow%3Abuild
+[codestyle]: https://img.shields.io/badge/code%20style-PSR12-brightgreen
+[phpstan]: https://img.shields.io/badge/phpstan-level%205-green

--- a/composer.json
+++ b/composer.json
@@ -111,12 +111,12 @@
         "fix": [
             "@phpcbf"
         ],
-        "lint": "parallel-lint --exclude app --exclude var --exclude vendor .",
-        "phpcs": "phpcs --runtime-set ignore_warnings_on_exit 1",
+        "lint": "parallel-lint $PHPLINT_FLAGS --exclude app --exclude var --exclude vendor .",
+        "phpcs": "phpcs $PHPCS_FLAGS --runtime-set ignore_warnings_on_exit 1",
         "phpcbf": "phpcbf",
         "phpstan": [
             "@php bin/console cache:warmup -q",
-            "phpstan analyse --ansi"
+            "phpstan analyse $PHPSTAN_FLAGS --ansi"
         ],
         "post-install-cmd": [
             "@auto-scripts"

--- a/composer.json
+++ b/composer.json
@@ -93,6 +93,7 @@
     },
     "scripts": {
         "auto-scripts": {
+            "parallel-lint src": "script",
             "cache:clear": "symfony-cmd",
             "assets:install %PUBLIC_DIR%": "symfony-cmd"
         },


### PR DESCRIPTION
Once this is merged, `composer check` will be run on each push to `main` and each pull request targeting `main`.

### Errors to fix before the CI can pass

#### Fix composer.json
You can check that it is correct using `composer validate`. To fix it you will first have to add these two fields:

- `name` : The property name is required
- `description` : The property description is required

You should also fix the `license` field to reflect the current license: `AGPL-3.0-or-later`

Then run `composer update --lock` to update the lockfile and get rid of the following error:
> The lock file is not up to date with the latest changes in composer.json

#### Fix the last phpcs errors

    composer fix

### Example commit that fixes the CI

https://github.com/n-peugnet/antilope/commit/746957c2537716f4c8b0244f355e9310c77fd19a

Successful run: https://github.com/n-peugnet/antilope/actions/runs/488601692

### Linked Issues

Fixes #17 