### PR TITLE
fix(ui): add basic styles for blockquotes

### DIFF
--- a/public/antilope.css
+++ b/public/antilope.css
@@ -1,0 +1,6 @@
+/* fix blockquote styles */
+blockquote {
+    padding: 0 0.5rem;
+    color: var(--gray);
+    border-left: .2rem solid var(--gray);
+}

--- a/templates/base.html.twig
+++ b/templates/base.html.twig
@@ -8,6 +8,7 @@
         <!--<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">-->
         <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootswatch/4.5.2/darkly/bootstrap.min.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.2/css/all.min.css" integrity="sha512-HK5fgLBL+xu6dm/Ii3z4xhlSUyZgTT9tuc/hSrtw6uzJOvgRr2a9jyxxT1ely+B+xFAmJKVSTbpM/CuL7qxO8w==" crossorigin="anonymous" />
+        <link rel="stylesheet" href="{{ asset('/antilope.css') }}" />
         {% block stylesheets %}
         {% endblock %}
     </head>


### PR DESCRIPTION
### Before

![2021-03-17-160059_704x378_scrot](https://user-images.githubusercontent.com/23519418/111488973-0663f880-873a-11eb-8af1-355ff29e3356.png)
![2021-03-17-160039_706x298_scrot](https://user-images.githubusercontent.com/23519418/111488986-0a901600-873a-11eb-9e15-bf6b483ddb68.png)

### After

![2021-03-17-155959_704x383_scrot](https://user-images.githubusercontent.com/23519418/111489021-12e85100-873a-11eb-8d51-ba1e8b752e3f.png)
![2021-03-17-160017_698x304_scrot](https://user-images.githubusercontent.com/23519418/111489038-154aab00-873a-11eb-849b-47f9d93145c3.png)
