### PR TITLE
fix: images were loaded in http when behind a proxy

### DIFF
--- a/.env
+++ b/.env
@@ -31,4 +31,8 @@ APP_ENV=dev
 # DATABASE_URL="postgresql://db_user:db_password@127.0.0.1:5432/db_name?serverVersion=13&charset=utf8"
 ###< doctrine/doctrine-bundle ###
 
+# relative path to public folder's true location
 LIIP_PUBLIC_PATH="public"
+
+# trusted proxy addresses, if behind a reverse proxy. By default trust local proxy
+TRUSTED_PROXIES=127.0.0.1,::1

--- a/config/packages/framework.yaml
+++ b/config/packages/framework.yaml
@@ -3,6 +3,8 @@ framework:
     secret: '%env(APP_SECRET)%'
     #csrf_protection: true
     #http_method_override: true
+    trusted_proxies: '%env(TRUSTED_PROXIES)%'
+
 
     # Enables session support. Note that the session will ONLY be started if you read or write from it.
     # Remove or comment this section to explicitly disable session support.


### PR DESCRIPTION
set the `trusted_proxies` setting from environment
and trust local proxy by default

Fixes #96
